### PR TITLE
Move to a logging framework

### DIFF
--- a/src/example/java/com/gikk/twirk/BotExample.java
+++ b/src/example/java/com/gikk/twirk/BotExample.java
@@ -6,6 +6,7 @@ import com.gikk.twirk.events.TwirkListener;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Scanner;
+import java.util.logging.Level;
 
 /**Simple example of how Twirk can be used. <br><br>
  * 
@@ -27,8 +28,8 @@ public class BotExample {
 		String channel = "#" + scanner.nextLine();
 		
 		final Twirk twirk = new TwirkBuilder(channel, SETTINGS.MY_NICK, SETTINGS.MY_PASS)
-								.setVerboseMode(true)	//We want to print everything we receive from Twitch
-								.build();				//Create the Twirk object
+								.setVerbosity(Level.ALL)  //We want to print everything we receive from Twitch
+								.build();				  //Create the Twirk object
 		
 		twirk.addIrcListener( getOnDisconnectListener(twirk) );
 		twirk.addIrcListener( new PatternCommandExample(twirk) );

--- a/src/main/java/com/gikk/twirk/OutputThread.java
+++ b/src/main/java/com/gikk/twirk/OutputThread.java
@@ -116,9 +116,7 @@ class OutputThread extends Thread{
 			System.err.println("Twirk is not connected! Sending messages will not succeed!");
 		}
 
-        if(connection.verboseMode) {
-            System.out.println("OUT " + message);
-        }
+		connection.logger.fine("OUT " + message);
 
 		/**An IRC message may not be longer than 512 characters. Also, they must end with \r\n,
 		 * so if the supplied message is longer than 510 characters, we have to cut it short.

--- a/src/main/java/com/gikk/twirk/Twirk.java
+++ b/src/main/java/com/gikk/twirk/Twirk.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 
 /**Class for communicating with the TwitchIrc chat.<br>
  * To create instances of Twirk, see {@link TwirkBuilder}.<br><br>
@@ -65,7 +66,6 @@ public final class Twirk {
 	private final String nick;
 	private final String pass;
 	private final String channel;
-	final boolean verboseMode;
 
 	private OutputThread outThread;
 	private InputThread inThread;
@@ -78,6 +78,7 @@ public final class Twirk {
 	private BufferedReader reader = null;
 
 	private final ArrayList<TwirkListener> listeners = new ArrayList<>();
+	final Logger logger = Logger.getLogger("Twirk");
 	final Set<String> moderators = Collections.newSetFromMap( new ConcurrentHashMap<>() );
 	final Set<String> online	 = Collections.newSetFromMap( new ConcurrentHashMap<>() );
 
@@ -100,7 +101,8 @@ public final class Twirk {
 		this.nick = builder.nick;
 		this.pass = builder.oauth;
 		this.channel = builder.channel;
-		this.verboseMode = builder.verboseMode;
+		
+		this.logger.setLevel(builder.verbosity);
 
 		this.clearChatBuilder = builder.getClearChatBuilder();
 		this.hostTargetBuilder= builder.getHostTargetBuilder();
@@ -329,9 +331,9 @@ public final class Twirk {
 
 		isConnected = false;
 
-		System.out.println("\n\tDisconnecting from Twitch chat...");
+		logger.info("\n\tDisconnecting from Twitch chat...");
 		releaseResources();
-		System.out.println("\tDisconnected from Twitch chat\n");
+		logger.info("\tDisconnected from Twitch chat\n");
 
 		for( TwirkListener l : listeners ) {
             l.onDisconnect();
@@ -354,9 +356,9 @@ public final class Twirk {
 		isConnected = false;
 		isDisposed = true;
 
-		System.out.println("\n\tDisposing of IRC...");
+		logger.info("\n\tDisposing of IRC...");
 		releaseResources();
-		System.out.println("\tDisposing of IRC completed\n");
+		logger.info("\tDisposing of IRC completed\n");
 	}
 
 
@@ -403,9 +405,8 @@ public final class Twirk {
         // Read lines from the server until it tells us we have connected.
         String line;
         while ((line = reader.readLine()) != null) {
-            if(verboseMode) {
-                System.out.println("IN  " + line);
-            }
+            logger.fine("IN  " + line);
+            
             //When we get a message containing 004, we have successfully logged in
             if (line.contains("004")) {
                 return true;
@@ -446,9 +447,8 @@ public final class Twirk {
     		// A PING contains the message "PING MESSAGE", and we want to reply with MESSAGE as well
     		// Hence, we reply "PONG MESSAGE" . That's where the substring(5) comes from bellow, we strip
     		//out everything but the message
-			if (verboseMode) {
-				System.out.println("IN  " + line);
-			}
+			logger.fine("IN  " + line);
+				
     		serverMessage("PONG " + line.substring(5) ); //Remove the "PING " part, and send the rest back
     		return;
 		}

--- a/src/main/java/com/gikk/twirk/TwirkBuilder.java
+++ b/src/main/java/com/gikk/twirk/TwirkBuilder.java
@@ -12,6 +12,8 @@ import com.gikk.twirk.types.users.TwitchUserBuilder;
 import com.gikk.twirk.types.users.UserstateBuilder;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.logging.Level;
+
 import javax.net.ssl.SSLSocketFactory;
 
 /**Class for creating instances of {@link Twirk}.<br>
@@ -30,8 +32,8 @@ public class TwirkBuilder {
 	//***********************************************************
 	// 				VARIABLES
 	//***********************************************************
-	boolean verboseMode = false;
-
+	Level verbosity = Level.INFO;
+	
 	String server = "irc.chat.twitch.tv";
 	int 	port  = 6697;
 	boolean useSSL = true;
@@ -106,14 +108,14 @@ public class TwirkBuilder {
 		return this;
 	}
 
-	/**Sets the {@link Twirk} object to VerboseMode<br>
-	 * In VerboseMode, every message that is received by {@link Twirk} will be printed to console. Default value is {@code false}
+	/**Sets the {@link Twirk} logger's verbosity<br>
+	 * With a verbosity greater or equal to fine, every message that is received by {@link Twirk} will be printed to console. Default value is {@code false}
 	 *
 	 * @param verboseMode {@code true} is you want {@link Twirk} in VerboseMode
 	 * @return this
 	 */
-	public TwirkBuilder setVerboseMode(boolean verboseMode){
-		this.verboseMode = verboseMode;
+	public TwirkBuilder setVerbosity(Level verbosity){
+		this.verbosity = verbosity;
 		return this;
 	}
 

--- a/src/main/java/com/gikk/twirk/TwirkMaintainanceListener.java
+++ b/src/main/java/com/gikk/twirk/TwirkMaintainanceListener.java
@@ -21,25 +21,21 @@ class TwirkMaintainanceListener implements TwirkListener{
 	
 	@Override
 	public void onAnything(String line) {
-		if( instance.verboseMode ) {
-            System.out.println("IN  "+line );
-        }
+        instance.logger.fine("IN  "+line );
 	}
 
 	@Override
 	public void onJoin(String joinedNick) {
 		if( !instance.online.add( joinedNick ) ) {
-			if(instance.verboseMode)
-            	System.out.println("\tUser " + joinedNick + " was already listed as online....");
+			instance.logger.fine("\tUser " + joinedNick + " was already listed as online....");
         }
 	}
 
 	@Override
 	public void onPart(String partedNick) {
 		if( !instance.online.remove( partedNick ) ) {
-			if(instance.verboseMode)
-				System.out.println("\tUser " + partedNick + " was not listed as online....");
-        }
+			instance.logger.fine("\tUser " + partedNick + " was not listed as online....");
+		}
 	}
 
 	@Override

--- a/src/test/java/com/gikk/twirk/TestSuit.java
+++ b/src/test/java/com/gikk/twirk/TestSuit.java
@@ -15,6 +15,8 @@ import com.gikk.twirk.types.users.TestUserstate;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,7 +42,7 @@ public class TestSuit {
         testTwirk = new TwirkBuilder("#testchan", "testbot", "password")
             .setSocket(socket)
             .setSSL(false)
-            .setVerboseMode(false)
+            .setVerbosity(Level.INFO)
             .build();
 
         tl = new TestTwirkListener();


### PR DESCRIPTION
Also make verbosity a log level instead of a boolean.

This allows us to silence all output from Twirk (Our console window currently looks like [this](https://i.imgur.com/BVThRUC.png))